### PR TITLE
Fix option for fallocate command in volumes.md

### DIFF
--- a/storage/volumes.md
+++ b/storage/volumes.md
@@ -576,7 +576,7 @@ The filesystem support of your system depends on the version of the Linux kernel
 1. Create a file and allocate some space to it:
 
    ```console
-   $ fallocate -f 1G disk.raw
+   $ fallocate -l 1G disk.raw
    ```
 
 2. Build a filesystem onto the `disk.raw` file:


### PR DESCRIPTION
fallocate does not have -f option.
the correct option to add the length of file is -l.
so the correct command here will be like this:
`fallocate -f 1G disk.raw`

